### PR TITLE
Fix typos in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ Dependency
 ----------
 
 You obviously need to have swift to run this as it is only a wrapper.
-You also need ruby and some of its gems : mechanize logger and highline.
+You also need ruby and some of its gems : mechanize, logger and highline.
 
 On debian, 
 
-    apt-get install swift ruby ruby-mechanize ruby-logger ruby-higline
+    apt-get install swift ruby ruby-mechanize ruby-logger ruby-highline
 
 will install everything that is needed. By the way this has only been
 tested on Debian, but should work on any recent GNU/Linux.

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Dependency
 You obviously need to have swift to run this as it is only a wrapper.
 You also need ruby and some of its gems : mechanize, logger and highline.
 
-On debian, 
+On debian,
 
     apt-get install swift ruby ruby-mechanize ruby-logger ruby-highline
 
@@ -68,14 +68,14 @@ information, and it might not be safer.
 BUGS
 ----
 No error detection is done. The way the hubic and openstack token are
-store might be unsafe. I should probably try to find a safe for them. 
+store might be unsafe. I should probably try to find a safe for them.
 
 If something stop working you could try
 
     ./hubic-swift --cleanup
 
 to remove the connexion token, and so to force hubic-swift to
-reconnect. 
+reconnect.
 
 Report any bug to the [github project page](https://github.com/vanicat/hubic-swift/issues?state=open)
 

--- a/hubic-swift
+++ b/hubic-swift
@@ -98,7 +98,7 @@ def ask_creds(askpass=true)
 
   unless @hubic_pass || not(askpass)
     @hubic_pass = ask_secret("What is your hubic password?")
-    print("This password won't be saved, you have to manualy edit ", File.absolute_path('creds', xdg_config_dir),"\n")
+    print("This password won't be saved, you have to manually edit ", File.absolute_path('creds', xdg_config_dir),"\n")
   end
 
   File.open(creds_file,File::CREAT|File::TRUNC|File::RDWR, 0600) do |fd|


### PR DESCRIPTION
I haven't been able to fetch an access token successfully -- I can't tell right now if the end point used by the script is deprecated or if it was down when I tried the script. Anyway, here's a few fixes for typos I've found while going through the script.
